### PR TITLE
Fix GroupBy deadlock for cancelled group subscriptions

### DIFF
--- a/Reactive4.NET.Test/FlowableGroupByTest.cs
+++ b/Reactive4.NET.Test/FlowableGroupByTest.cs
@@ -97,5 +97,29 @@ namespace Reactive4.NET.Test
                 .Test()
                 .AssertResult(1);
         }
+
+        [Test]
+        public void GroupUnsubscriptionOnError()
+        {
+            Flowable.Range(0, 1000)
+                .GroupBy(x => x % 2)
+                .FlatMap(g => g.Map<int, int>(x => throw new Exception()))
+                .Test()
+                .AwaitDone(TimeSpan.FromSeconds(5))
+                .AssertValueCount(0)
+                .AssertError(typeof(Exception));
+        }
+
+        [Test]
+        public void GroupUnsubscriptionOnErrorHidden()
+        {
+            Flowable.Range(0, 1000)
+                .GroupBy(x => x % 2)
+                .FlatMap(g => g.Hide().Map<int, int>(x => throw new Exception()).Hide())
+                .Test()
+                .AwaitDone(TimeSpan.FromSeconds(5))
+                .AssertValueCount(0)
+                .AssertError(typeof(Exception));
+        }
     }
 }

--- a/Reactive4.NET/operators/FlowableGroupBy.cs
+++ b/Reactive4.NET/operators/FlowableGroupBy.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -575,6 +575,7 @@ namespace Reactive4.NET.operators
                     var a = Volatile.Read(ref actual);
                     var q = queue;
                     var e = emitted;
+                    var p = parent;
 
                     for (;;)
                     {
@@ -587,6 +588,11 @@ namespace Reactive4.NET.operators
                             {
                                 if (Volatile.Read(ref cancelled))
                                 {
+                                    if (f != 0)
+                                    {
+                                        p.RequestInner(f);
+                                    }
+
                                     q.Clear();
                                     actual = null;
                                     return;
@@ -620,6 +626,11 @@ namespace Reactive4.NET.operators
                                 e++;
                                 f++;
                             }
+                            
+                            if (f != 0)
+                            {
+                                p.RequestInner(f);
+                            }
 
                             if (e == r)
                             {
@@ -647,11 +658,6 @@ namespace Reactive4.NET.operators
                                     }
                                     return;
                                 }
-                            }
-
-                            if (f != 0)
-                            {
-                                parent.RequestInner(f);
                             }
                         }
                         int w = Volatile.Read(ref wip);


### PR DESCRIPTION
This change ensures that more items are requested from the upstream when a group is cancelled just after publishing items.

Closes #14 